### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate Models - using litellm

### DIFF
--- a/chat/ai.py
+++ b/chat/ai.py
@@ -1,5 +1,6 @@
 from config import token
 import openai
+from litellm import acompletion
 from db.MySqlConn import config
 
 OPENAI_CHAT_COMPLETION_OPTIONS = {
@@ -26,7 +27,7 @@ async def ChatCompletionsAI(logged_in_user, messages) -> (str, str):
     else:
         OPENAI_CHAT_COMPLETION_OPTIONS["model"] = "gpt-3.5-turbo"
 
-    response = await openai.ChatCompletion.acreate(
+    response = await acompletion(
         messages=messages,
         max_tokens=token[level],
         **OPENAI_CHAT_COMPLETION_OPTIONS)

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ tqdm==4.64.1
 urllib3==1.26.14
 wakatime==13.1.0
 yarl==1.8.2
+litellm==0.1.400


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```python
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```
